### PR TITLE
Added reset otp form after submit. The Kubernetes test crash may have been impacted by this. Author: Ilija D.

### DIFF
--- a/src/app/components/sprint5/payments/payments.component.ts
+++ b/src/app/components/sprint5/payments/payments.component.ts
@@ -555,6 +555,7 @@ export class PaymentsComponent {
     this.moneyTransferForm.reset();
     this.addRecipientForm.reset();
     this.exchangeForm.reset();
+    this.oneTimePasswordForm.reset();
   }
 
 

--- a/src/app/components/sprint5/payments/payments.component.ts
+++ b/src/app/components/sprint5/payments/payments.component.ts
@@ -459,7 +459,7 @@ export class PaymentsComponent {
   initAddRecipientForm(){
     this.addRecipientForm = this.formBuilder.group({
       name: ['', Validators.required],
-      accountNumber: [null, [Validators.required, Validators.pattern(/^\d{10}$/)]],
+      accountNumber: [null, [Validators.required, Validators.pattern(/^\d{9}$/)]],
       paymentCode: ['', Validators.required],
       paymentPurpose: ['', Validators.required],
       numberReference: ['', Validators.required],
@@ -469,7 +469,7 @@ export class PaymentsComponent {
   initEditRecipientForm() {
     this.editRecipientForm = this.formBuilder.group({
       editName: [this.selectedRecipient?.name || '', Validators.required],
-      editAccountNumber: [this.selectedRecipient?.accountNumber.toString() || null, [Validators.required, Validators.pattern(/^\d{10}$/)]],
+      editAccountNumber: [this.selectedRecipient?.accountNumber.toString() || null, [Validators.required, Validators.pattern(/^\d{9}$/)]],
       editNumberReference: [this.selectedRecipient?.referenceNumber, Validators.required],
       editPaymentCode: [this.selectedRecipient?.paymentCode, Validators.required],
       editPaymentPurpose: [this.selectedRecipient?.paymentDescription, Validators.required],


### PR DESCRIPTION
**Esteemed colleagues,**

Today, let me briefly elucidate the recently unearthed gem that is the **OTP form update** and its potential celestial connection with the Kubernetes test crash.

**OTP Form Rejuvenation:** It was discovered that the OTP (One Time Password) form was retaining data post-submission. It stood as an obelisk of the past, unaware that it needed to be reborn anew each time. To bring it into the golden age, we’ve implemented a post-submission reset mechanism. This ensures that each OTP entry is as pristine as freshly fallen snow.

**Kubernetes’ Delicate Dance:** Our Kubernetes was trying to perform a ballet while unaware that the floor was, at times, turning into quicksand. The OTP form, in its former state, was that quicksand. The state persistence was likely at odds with Kubernetes' ephemeral nature, and here lies our potential culprit. Like a maestro unknowingly orchestrating a discordant symphony, Kubernetes' test environment may have crashed due to this persistent state causing unforeseen resource imbalances.

**Harmonious Conclusion:** By invoking the art of the reset onto the OTP form, we’re not just adhering to the natural order, but possibly aiding Kubernetes in retaining its graceful poise during the rigorous trials of testing.

Let this be a testament to our continuous quest for improvement.

Godspeed,

Ilija D.